### PR TITLE
Submitted to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mmconvert
-Version: 0.6
-Date: 2023-03-28
+Version: 0.8
+Date: 2023-03-29
 Title: Mouse Map Converter
-Description: Function to convert mouse genome positions between the build 39 physical map and the Cox genetic map <doi:10.1534/genetics.109.105486>.
+Description: Convert mouse genome positions between the build 39 physical map and the genetic map of Cox et al. (2009) <doi:10.1534/genetics.109.105486>.
 Author: Karl W Broman [aut, cre] (<https://orcid.org/0000-0002-4914-6671>)
 Maintainer: Karl W Broman <broman@wisc.edu>
 Authors@R: person("Karl W", "Broman", role=c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: mmconvert
-Version: 0.5-2
+Version: 0.6
 Date: 2023-03-28
 Title: Mouse Map Converter
 Description: Function to convert mouse genome positions between the build 39 physical map and the Cox genetic map <doi:10.1534/genetics.109.105486>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## mmconvert 0.8 (2023-03-29)
+
+- Small changes for CRAN submission.
+
+
 ## mmconvert 0.6 (2023-03-28)
 
 - Added dataset `grcm39_chrlen` with lengths of GRCm39 chromosomes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## mmconvert 0.5-2 (2023-03-28)
+## mmconvert 0.6 (2023-03-28)
 
 - Added dataset `grcm39_chrlen` with lengths of GRCm39 chromosomes
   in basepairs.

--- a/R/cross2_to_grcm39.R
+++ b/R/cross2_to_grcm39.R
@@ -22,7 +22,8 @@
 #' @seealso [MUGAmaps]
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
+#' library(qtl2)
 #' file <- paste0("https://raw.githubusercontent.com/rqtl/",
 #'                "qtl2data/main/DOex/DOex.zip")
 #' DOex <- read_cross2(file)

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,11 +11,8 @@ the [Cox genetic map](https://doi.org/10.1534/genetics.109.105486) positions.
 for the build 39 physical map.)
 
 The package is a reimplementation of part of the basic functionality
-of the [mouse map
-converter](https://churchill-lab.jax.org/mousemapconverter) web
-service from [Gary Churchill's
-group](https://churchill-lab.jax.org/website/) at the [Jackson
-Lab](https://jax.org).
+of the mouse map converter web service from Gary Churchill's group at
+the [Jackson Lab](https://www.jax.org).
 
 ---
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ for the build 39 physical map.)
 
 The package is a reimplementation of part of the basic functionality
 of the mouse map converter web service from Gary Churchill's group at
-the [Jackson Lab](https://www.jax.org).
+the Jackson Lab.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@ the [Cox genetic map](https://doi.org/10.1534/genetics.109.105486) positions.
 for the build 39 physical map.)
 
 The package is a reimplementation of part of the basic functionality
-of the [mouse map
-converter](https://churchill-lab.jax.org/mousemapconverter) web
-service from [Gary Churchill's
-group](https://churchill-lab.jax.org/website/) at the [Jackson
-Lab](https://jax.org).
+of the mouse map converter web service from Gary Churchill's group at
+the [Jackson Lab](https://www.jax.org).
 
 ---
 
@@ -79,9 +76,9 @@ mmconvert(input_df)
 
 ```
 ##                      marker chr cM_coxV3_ave cM_coxV3_female cM_coxV3_male bp_grcm39 Mbp_grcm39
-## rs13482072       rs13482072  14      0.36404         0.38860       0.34262   6738536   6.738536
-## rs13482231       rs13482231  14     28.63568        34.85621      22.71767  67215850  67.215850
-## gnf14.117.278 gnf14.117.278  14     59.57310        64.62113      55.06443 121955310 121.955310
+## rs13482072       rs13482072  14    0.3938878       0.4204617     0.3707116   6738536   6.738536
+## rs13482231       rs13482231  14   28.7007118      34.8398609    22.8635376  67215850  67.215850
+## gnf14.117.278 gnf14.117.278  14   59.5630160      64.5897950    55.0750080 121955310 121.955310
 ```
 
 If you want to give the input positions in Mbp rather than basepairs,
@@ -95,9 +92,9 @@ mmconvert(input_df, input_type="Mbp")
 
 ```
 ##                      marker chr cM_coxV3_ave cM_coxV3_female cM_coxV3_male bp_grcm39 Mbp_grcm39
-## rs13482072       rs13482072  14      0.36404         0.38860       0.34262   6738536   6.738536
-## rs13482231       rs13482231  14     28.63568        34.85621      22.71767  67215850  67.215850
-## gnf14.117.278 gnf14.117.278  14     59.57310        64.62113      55.06443 121955310 121.955310
+## rs13482072       rs13482072  14    0.3938878       0.4204617     0.3707116   6738536   6.738536
+## rs13482231       rs13482231  14   28.7007118      34.8398609    22.8635376  67215850  67.215850
+## gnf14.117.278 gnf14.117.278  14   59.5630160      64.5897950    55.0750080 121955310 121.955310
 ```
 
 The input positions can also be provided in sex-averaged, female, or male cM.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for the build 39 physical map.)
 
 The package is a reimplementation of part of the basic functionality
 of the mouse map converter web service from Gary Churchill's group at
-the [Jackson Lab](https://www.jax.org).
+the Jackson Lab.
 
 ---
 

--- a/man/cross2_to_grcm39.Rd
+++ b/man/cross2_to_grcm39.Rd
@@ -27,7 +27,8 @@ positions, revising marker order and omitting markers that are not
 found.
 }
 \examples{
-\dontrun{
+\donttest{
+library(qtl2)
 file <- paste0("https://raw.githubusercontent.com/rqtl/",
                "qtl2data/main/DOex/DOex.zip")
 DOex <- read_cross2(file)


### PR DESCRIPTION
- removed jax.org URLs as they were giving various warnings about certificates

- changes to package description requested by CRAN

- changed `\dontrun{ }` to `\donttest{ }` in example for `cross2_to_grcm39()`